### PR TITLE
Make tf_bag compatible with bags recorded with "tf" and "/tf" as topic names

### DIFF
--- a/src/tf_bag.py
+++ b/src/tf_bag.py
@@ -22,7 +22,7 @@ class BagTfTransformer(object):
         """
         if type(bag) == str:
             bag = rosbag.Bag(bag)
-        self.tf_messages = sorted((tm for m in bag if m.topic == '/tf' for tm in m.message.transforms),
+        self.tf_messages = sorted((tm for m in bag if m.topic.strip("/") == 'tf' for tm in m.message.transforms),
                                   key=lambda tfm: tfm.header.stamp.to_nsec())
         self.tf_times = np.array(list((tfm.header.stamp.to_nsec() for tfm in self.tf_messages)))
         self.transformer = tf.TransformerROS()


### PR DESCRIPTION
This solves issue #1, tested on bags recorded with `rosbag record tf` and with `rosbag record /tf`.

@marcoesposito1988, your solution was exactly right :)