### PR TITLE
TransformerROS.setTransform works only for non static tfs

### DIFF
--- a/src/tf_bag.py
+++ b/src/tf_bag.py
@@ -91,7 +91,7 @@ class BagTfTransformer(object):
             self.transformer.setTransform(m)
         for st_tfm in self.tf_static_messages:
             st_tfm.header.stamp = target_time
-            self.transformer.setTransform(st_tfm)
+            self.transformer._buffer.set_transform_static(st_tfm, "default_authority")
 
         self.last_population_range = (target_start_time, target_end_time)
 


### PR DESCRIPTION
when looking in the inner mecanism of TransformerROS class,
https://github.com/ros/geometry/blob/00a32d024af476bf50822e6df2fe2ec97765b1a9/tf/src/tf/listener.py#L62-L63
You see that `setTransform` calls `buffer.set_transform` instead of `buffer.set_transform_static` which is the correct way to use static transforms.
Without this some lookup may fail.