### PR TITLE
Modified setup.py to enable pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
-from setuptools import setup
-from catkin_pkg.python_setup import generate_distutils_setup
+import setuptools
 
-d = generate_distutils_setup(
-    packages=['tf_bag'],
+
+setuptools.setup(
+    name='tf_bag',
+    version='1.0.0',
+    author='Marco Esposito',
+    packages=setuptools.find_packages(where='src'),
     package_dir={'': 'src'}
 )
-
-setup(**d)

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,6 @@ setuptools.setup(
     name='tf_bag',
     version='1.0.0',
     author='Marco Esposito',
-    packages=setuptools.find_packages(where='src'),
+    py_modules=['tf_bag'],
     package_dir={'': 'src'}
 )


### PR DESCRIPTION
I was interested in using this for post processing without requiring a large ROS install. Made a small change to `setup.py`.